### PR TITLE
HTML rendering of AttributedStrings is now deferred into TextSectionView

### DIFF
--- a/FringePlanner/Content/EventDetailsContentContainer/EventDetailsContentContainer+Structure+DescriptionStructure.swift
+++ b/FringePlanner/Content/EventDetailsContentContainer/EventDetailsContentContainer+Structure+DescriptionStructure.swift
@@ -10,9 +10,9 @@ import SwiftUI
 extension EventDetailsContentContainer.Structure {
     /// Structure for the description portion of the event details
     struct DescriptionStructure: BaseStructureProtocol {
-        let descriptionTeaser: AttributedString?
-        let description: AttributedString
-        let warnings: AttributedString?
+        let descriptionTeaser: AttributedString.StringProvider?
+        let description: AttributedString.StringProvider
+        let warnings: AttributedString.StringProvider?
         
         var structure: some ViewDataProtocol {
             GroupData(type: .section) {
@@ -23,7 +23,7 @@ extension EventDetailsContentContainer.Structure {
         }
         
         @FringeDataResultBuilder
-        static func getTeaserRow(from teaser: AttributedString?, description: AttributedString) -> some ViewDataProtocol {
+        static func getTeaserRow(from teaser: AttributedString.StringProvider?, description: AttributedString.StringProvider) -> some ViewDataProtocol {
             // The teaser should not be shown if it appears in the description, otherwise it will look duplicated.
             if let teaser, !description.hasTrimmedPrefix(teaser) {
                 SectionRowData(text: teaser)
@@ -31,12 +31,12 @@ extension EventDetailsContentContainer.Structure {
         }
         
         @FringeDataResultBuilder
-        static func getDescriptionRow(from description: AttributedString) -> some ViewDataProtocol {
+        static func getDescriptionRow(from description: AttributedString.StringProvider) -> some ViewDataProtocol {
             SectionRowData(text: description)
         }
         
         @FringeDataResultBuilder
-        static func getWarningsRow(from warnings: AttributedString?) -> some ViewDataProtocol {
+        static func getWarningsRow(from warnings: AttributedString.StringProvider?) -> some ViewDataProtocol {
             if let warnings {
                 SectionRowData(title: "Warnings", text: warnings)
             }
@@ -45,15 +45,13 @@ extension EventDetailsContentContainer.Structure {
 }
 
 extension EventDetailsContentContainer.Structure.DescriptionStructure {
-    @MainActor
     init(event: DBFringeEvent) {
         self.init(descriptionTeaser: event.descriptionTeaser, description: event.eventDescription, warnings: event.warnings)
     }
     
-    @MainActor
     init(descriptionTeaser: String?, description: String, warnings: String? ) {
-        self.descriptionTeaser = descriptionTeaser.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
-        self.description = AttributedString(fromHTML: description) ?? AttributedString(description)
-        self.warnings = warnings.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
+        self.descriptionTeaser = descriptionTeaser.map { AttributedString.StringProvider($0) }
+        self.description = AttributedString.StringProvider(description)
+        self.warnings = warnings.map { AttributedString.StringProvider($0) }
     }
 }

--- a/FringePlanner/Content/EventDetailsContentContainer/EventDetailsContentContainer+Structure+DetailsStructure.swift
+++ b/FringePlanner/Content/EventDetailsContentContainer/EventDetailsContentContainer+Structure+DetailsStructure.swift
@@ -10,13 +10,13 @@ import SwiftUI
 extension EventDetailsContentContainer.Structure {
     /// Structure for the general details portion of the event details
     struct DetailsStructure: BaseStructureProtocol {
-        let title: AttributedString
-        let subTitle: AttributedString?
-        let artist: AttributedString?
-        let country: AttributedString?
-        let ageCategory: AttributedString?
-        let genre: AttributedString
-        let genreTags: AttributedString?
+        let title: AttributedString.StringProvider
+        let subTitle: AttributedString.StringProvider?
+        let artist: AttributedString.StringProvider?
+        let country: AttributedString.StringProvider?
+        let ageCategory: AttributedString.StringProvider?
+        let genre: AttributedString.StringProvider
+        let genreTags: AttributedString.StringProvider?
         
         var structure: some ViewDataProtocol {
             GroupData(type: .section(title: "Details")) {
@@ -37,50 +37,50 @@ extension EventDetailsContentContainer.Structure {
         }
 
         @FringeDataResultBuilder
-        static func getArtistRow(from artist: AttributedString?) -> some ViewDataProtocol {
+        static func getArtistRow(from artist: AttributedString.StringProvider?) -> some ViewDataProtocol {
             if let artist {
                 SectionRowData(title: "Artist", text: artist)
             }
         }
         
         @FringeDataResultBuilder
-        static func getTitleRow(from title: AttributedString) -> SectionRowData {
+        static func getTitleRow(from title: AttributedString.StringProvider) -> SectionRowData {
             SectionRowData(title: "Title", text: title)
         }
 
         @FringeDataResultBuilder
-        static func getSubTitleRow(from subTitle: AttributedString?) -> some ViewDataProtocol {
+        static func getSubTitleRow(from subTitle: AttributedString.StringProvider?) -> some ViewDataProtocol {
             if let subTitle {
                 SectionRowData(title: "Subtitle", text: subTitle)
             }
         }
         
         @FringeDataResultBuilder
-        static func getArtistAndTitleRow(from artistAndTitle: AttributedString) -> SectionRowData {
+        static func getArtistAndTitleRow(from artistAndTitle: AttributedString.StringProvider) -> SectionRowData {
             SectionRowData(title: "Artist & Title", text: artistAndTitle)
         }
         
         @FringeDataResultBuilder
-        static func getCountryRow(from country: AttributedString?) -> some ViewDataProtocol {
+        static func getCountryRow(from country: AttributedString.StringProvider?) -> some ViewDataProtocol {
             if let country {
                 SectionRowData(title: "Country", text: country)
             }
         }
         
         @FringeDataResultBuilder
-        static func getAgeCategoryRow(from ageCategory: AttributedString?) -> some ViewDataProtocol {
+        static func getAgeCategoryRow(from ageCategory: AttributedString.StringProvider?) -> some ViewDataProtocol {
             if let ageCategory {
                 SectionRowData(title: "Age Category", text: ageCategory)
             }
         }
         
         @FringeDataResultBuilder
-        static func getGenreRow(from genre: AttributedString) -> SectionRowData {
+        static func getGenreRow(from genre: AttributedString.StringProvider) -> SectionRowData {
             SectionRowData(title: "Genre", text: genre)
         }
         
         @FringeDataResultBuilder
-        static func getGenreTagsRow(from genreTags: AttributedString?) -> some ViewDataProtocol {
+        static func getGenreTagsRow(from genreTags: AttributedString.StringProvider?) -> some ViewDataProtocol {
             if let genreTags {
                 SectionRowData(title: "Genre Tags", text: genreTags)
             }
@@ -89,7 +89,6 @@ extension EventDetailsContentContainer.Structure {
 }
 
 extension EventDetailsContentContainer.Structure.DetailsStructure {
-    @MainActor
     init(event: DBFringeEvent) {
         self.init(
             title: event.title,
@@ -102,7 +101,6 @@ extension EventDetailsContentContainer.Structure.DetailsStructure {
         )
     }
         
-    @MainActor
     init(
         title: String,
         subTitle: String?,
@@ -112,12 +110,12 @@ extension EventDetailsContentContainer.Structure.DetailsStructure {
         genre: String,
         genreTags: String?
     ) {
-        self.title = AttributedString(fromHTML: title) ?? AttributedString(title)
-        self.subTitle = subTitle.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
-        self.artist = artist.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
-        self.country = country.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
-        self.ageCategory = ageCategory.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
-        self.genre = AttributedString(fromHTML: genre) ?? AttributedString(genre)
-        self.genreTags = genreTags.map { AttributedString(fromHTML: $0) ?? AttributedString($0) }
+        self.title = AttributedString.StringProvider(title)
+        self.subTitle = subTitle.map { AttributedString.StringProvider($0) }
+        self.artist = artist.map { AttributedString.StringProvider($0) }
+        self.country = country.map { AttributedString.StringProvider($0) }
+        self.ageCategory = ageCategory.map { AttributedString.StringProvider($0) }
+        self.genre = AttributedString.StringProvider(genre)
+        self.genreTags = genreTags.map { AttributedString.StringProvider($0) }
     }
 }

--- a/FringePlanner/Extension/AttributedString.swift
+++ b/FringePlanner/Extension/AttributedString.swift
@@ -7,22 +7,6 @@
 
 import SwiftUI
 
-// MARK: - General
-
-extension AttributedString {
-    /// Returns true if the string includes the prefix after both string are trimmed.
-    func hasTrimmedPrefix(_ prefix: AttributedString?) -> Bool {
-        // Prefix must exist to be a prefix for the title
-        guard let prefix else { return false }
-        // Get the string values for each so that they can be evaluated
-        let stringPrefix = NSAttributedString(prefix).string
-        let stringSelf = NSAttributedString(self).string
-        // Values must be trimmed of whitespace before comparison as the attributed string generated from HTML
-        // may have whitespace which is not part of the default decoding
-        return stringSelf.trimmed.hasPrefix(stringPrefix.trimmed)
-    }
-}
-
 // MARK: - Generation from HTML
 
 extension AttributedString {
@@ -102,6 +86,34 @@ extension AttributedString {
                 self = .htmlString(string)
             } else {
                 self = .attributedString(AttributedString(string))
+            }
+        }
+        
+        /// Returns true if the string includes the prefix after both strings are processed.
+        /// Processing includes:
+        /// - Removing HTML tags
+        /// - Normalizing typographic characters (converting curly quotes to straight quotes)
+        /// - Trimming whitespace
+        /// This ensures consistent comparison regardless of formatting differences.
+        func hasTrimmedPrefix(_ stringProvider: AttributedString.StringProvider?) -> Bool {
+            // Prefix must exist to be a prefix for the title
+            guard let stringProvider else { return false }
+            // Values must be trimmed of whitespace before comparison as the attributed string generated from HTML
+            // may have whitespace which is not part of the default decoding
+            let string1 = self.rawString.withoutHTMLTags.typographicallyEnhanced.trimmed
+            let string2 = stringProvider.rawString.withoutHTMLTags.typographicallyEnhanced.trimmed
+            return string1.hasPrefix(string2)
+        }
+        
+        /// Returns the raw string content regardless of the provider type
+        /// - For attributed string: converts characters to a standard string
+        /// - For HTML string: returns the original HTML content
+        private var rawString: String {
+            switch self {
+            case .attributedString(let attributedString):
+                return String(attributedString.characters)
+            case .htmlString(let htmlString):
+                return htmlString
             }
         }
     }

--- a/FringePlanner/Extension/AttributedString.swift
+++ b/FringePlanner/Extension/AttributedString.swift
@@ -82,3 +82,27 @@ extension AttributedString {
         return String(format: "#%02X%02X%02X", Int(red * 255), Int(green * 255), Int(blue * 255))
     }
 }
+
+// MARK: - StringProvider
+
+extension AttributedString {
+    /// An enum that provides attributed text content with deferred processing for HTML strings.
+    enum StringProvider: Equatable {
+        /// Content that is already in AttributedString format
+        case attributedString(AttributedString)
+        /// HTML string content that will be converted later to AttributedString
+        case htmlString(String)
+
+        /// Creates a provider by automatically detecting if the string contains HTML
+        /// - Parameter string: The input string to analyze
+        /// If string contains HTML markers, it's stored as htmlString for later conversion
+        /// Otherwise, it's immediately converted to AttributedString
+        init(_ string: String) {
+            if string.mayContainHTML {
+                self = .htmlString(string)
+            } else {
+                self = .attributedString(AttributedString(string))
+            }
+        }
+    }
+}

--- a/FringePlanner/Extension/String.swift
+++ b/FringePlanner/Extension/String.swift
@@ -15,4 +15,13 @@ extension String {
     var nilOnEmpty: Self? {
         return !self.isEmpty ? self : nil
     }
+    
+    /// Performs a basic check to determine if the string might contain HTML
+    /// by looking for patterns like "<tag>"
+    var mayContainHTML: Bool {
+        // Look for a pattern that starts with < followed by a letter (tag name)
+        // This helps distinguish HTML tags from mathematical expressions
+        let pattern = "<[a-zA-Z][^>]*>"
+        return self.range(of: pattern, options: .regularExpression) != nil
+    }
 }

--- a/FringePlanner/Extension/String.swift
+++ b/FringePlanner/Extension/String.swift
@@ -6,6 +6,9 @@
 //
 
 extension String {
+    /// Pattern to match HTML tags
+    private static let htmlTagPattern = "</?[a-zA-Z][^>]*>"
+
     /// Returns a string without the new lines
     var trimmed: Self {
         self.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -21,7 +24,14 @@ extension String {
     var mayContainHTML: Bool {
         // Look for a pattern that starts with < followed by a letter (tag name)
         // This helps distinguish HTML tags from mathematical expressions
-        let pattern = "<[a-zA-Z][^>]*>"
-        return self.range(of: pattern, options: .regularExpression) != nil
+        return self.range(of: Self.htmlTagPattern, options: .regularExpression) != nil
+    }
+    
+    /// Returns the string with all HTML tags removed
+    /// Preserves the text content between tags
+    var withoutHTMLTags: Self {
+        // Match HTML tags that start with < followed by a letter or / (for closing tags)
+        // This avoids matching mathematical expressions like "2 < 3"
+        return self.replacingOccurrences(of: Self.htmlTagPattern, with: "", options: .regularExpression)
     }
 }

--- a/FringePlanner/Extension/String.swift
+++ b/FringePlanner/Extension/String.swift
@@ -13,6 +13,30 @@ extension String {
     var trimmed: Self {
         self.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    /// Returns a string with proper typographic characters and normalized quotes
+    var typographicallyEnhanced: Self {
+        var result = self
+        
+        // Convert any curly quotes to standard straight quotes
+        result = result.replacingOccurrences(of: "\u{201C}", with: "\"") // Left double quote to straight quote
+        result = result.replacingOccurrences(of: "\u{201D}", with: "\"") // Right double quote to straight quote
+        result = result.replacingOccurrences(of: "\u{2018}", with: "'") // Left single quote to straight quote
+        result = result.replacingOccurrences(of: "\u{2019}", with: "'") // Right single quote to straight quote
+        
+        // Replace three dots with ellipsis
+        result = result.replacingOccurrences(of: "...", with: "\u{2026}")
+        
+        // Replace common symbol representations
+        result = result.replacingOccurrences(of: "(c)", with: "\u{00A9}") // Copyright
+        result = result.replacingOccurrences(of: "(r)", with: "\u{00AE}") // Registered trademark
+        result = result.replacingOccurrences(of: "(tm)", with: "\u{2122}") // Trademark
+        
+        // Replace double hyphen with em dash
+        result = result.replacingOccurrences(of: "--", with: "\u{2014}")
+        
+        return result
+    }
     
     /// Will return nil if the string is empty
     var nilOnEmpty: Self? {

--- a/FringePlanner/ViewDatas/DatabaseItemsData.swift
+++ b/FringePlanner/ViewDatas/DatabaseItemsData.swift
@@ -41,8 +41,6 @@ extension DatabaseItemsData {
     struct ContentView: View, ViewProtocol {
         @Query var models: [Element]
         let data: DatabaseItemsData<Element, ElementViewData>
-        // A cache for the ViewData models
-        @State private var processedViewData: [Element.ID: ElementViewData] = [:]
 
         init(data: DatabaseItemsData<Element, ElementViewData>) {
             // Set the sorting of the models at the database level if possible
@@ -57,25 +55,9 @@ extension DatabaseItemsData {
         }
     
         var body: some View {
-            ForEach(sortedModels) { model in
-                // Some UI elements (such as the AttributedString) must be processed on the main thread
-                // so we need to ensure that the view data is processed outside of the view update cycle
-                
-                // If the view data has already been processed, use the cached version
-                if let cachedViewData = processedViewData[model.id] {
-                    cachedViewData.createView()
-                } else {
-                    Color.clear
-                        .task(id: model.id) {
-                            // Process the view data outside the view update cycle
-                            let viewData = data.elementView(model)
-                            await MainActor.run { processedViewData[model.id] = viewData }
-                        }
-                }
-            }
-            .onChange(of: models) {
-                // Clear cache when models change
-                processedViewData.removeAll()
+            // Loops through the sorted models and displays them
+            ForEach(sortedModels) { event in
+                data.elementView(event).createView()
             }
         }
 

--- a/FringePlanner/ViewDatas/SectionRowData/SectionRowData.swift
+++ b/FringePlanner/ViewDatas/SectionRowData/SectionRowData.swift
@@ -29,7 +29,7 @@ struct SectionRowData: ViewDataProtocol, Equatable {
     /// The content to be used for the row
     enum ValueType: Equatable {
         case url(title: String, value: String, url: String)
-        case text(title: String?, text: AttributedString)
+        case text(title: String?, text: AttributedString.StringProvider)
         case button(title: String, closure: MakeEquatableReadOnly<(() -> Void)>)
     }
 }
@@ -38,17 +38,15 @@ struct SectionRowData: ViewDataProtocol, Equatable {
 
 extension SectionRowData {
     init(title: String? = nil, text: AttributedString) {
+        self.value = .text(title: title, text: .attributedString(text))
+    }
+    
+    init(title: String? = nil, text: AttributedString.StringProvider) {
         self.value = .text(title: title, text: text)
     }
     
-    @MainActor
-    init(title: String? = nil, html: String) {
-        let attributedStringText = AttributedString(fromHTML: html) ?? .init(html)
-        self = .init(title: title, text: attributedStringText)
-    }
-    
     init(title: String? = nil, text: String) {
-        self.value = .text(title: title, text: AttributedString(text))
+        self.value = .text(title: title, text: .init(text))
     }
     
     init(title: String, value: URL) {

--- a/FringePlanner/ViewDatas/SectionRowData/TextSectionView.swift
+++ b/FringePlanner/ViewDatas/SectionRowData/TextSectionView.swift
@@ -13,15 +13,55 @@ import SwiftUI
 struct TextSectionView: View {
     /// Note: If the title is included, the `text` will not include custom formatting
     let title: String?
-    let text: AttributedString
+    let text: AttributedString.StringProvider
+    /// Stores the converted AttributedString from HTML when needed
+    @State private var attributedContent: AttributedString?
 
     var body: some View {
-        if let title {
-            LabeledContent(title) {
-                Text(text)
+        Group {
+            if let title {
+                LabeledContent(title) {
+                    textView
+                }
+            } else {
+                textView
             }
-        } else {
-            Text(text)
+        }
+        .task {
+            // Trigger async HTML conversion when view appears
+            await loadAttributedContent()
+        }
+    }
+
+    /// Provides the appropriate text view based on content type
+    @ViewBuilder
+    private var textView: some View {
+        switch text {
+        case .attributedString(let attributedString):
+            // Direct rendering for already-attributed content
+            Text(attributedString)
+        case .htmlString:
+            if let attributedContent {
+                // Show converted HTML content when available
+                Text(attributedContent)
+            } else {
+                // Show loading indicator while HTML is being processed
+                ProgressView()
+            }
+        }
+    }
+    
+    /// Converts HTML string to AttributedString asynchronously on the main actor
+    @MainActor
+    private func loadAttributedContent() async {
+        switch text {
+        case .attributedString:
+            // No conversion needed for already-attributed content
+            break
+        case .htmlString(let htmlString):
+            guard attributedContent == nil else { return }
+            // Convert HTML to AttributedString with fallback to plain text if conversion fails
+            attributedContent = AttributedString(fromHTML: htmlString) ?? AttributedString(htmlString)
         }
     }
 }
@@ -29,12 +69,12 @@ struct TextSectionView: View {
 extension TextSectionView {
     init(title: String?, text: String) {
         self.title = title
-        self.text = .init(stringLiteral: text)
+        self.text = .attributedString(AttributedString(text))
     }
     /// Note: If the title is included, the `text` will not include custom formatting
     init(title: String?, html: String) {
         self.title = title
-        self.text = AttributedString(fromHTML: html) ?? .init(stringLiteral: html)
+        self.text = .htmlString(html)
     }
 }
 

--- a/FringePlannerTests/ExtensionTests/AttributedStringTests.swift
+++ b/FringePlannerTests/ExtensionTests/AttributedStringTests.swift
@@ -78,4 +78,21 @@ struct AttributedStringTests {
             #expect(!AttributedString("123 Some Text").hasTrimmedPrefix("123 Other Text"))
         }
     }
+
+    @Suite("StringProvider")
+    struct StringProviderTests {
+        @Test("init correctly identifies HTML content")
+        func testInitWithHTMLContent() throws {
+            let htmlString = "<p>This is <b>HTML</b> content</p>"
+            try #require(htmlString.mayContainHTML, "Sanity Check: HTML string should be detected as containing HTML")
+            #expect(AttributedString.StringProvider(htmlString) == .htmlString(htmlString))
+        }
+        
+        @Test("init correctly handles plain text")
+        func testInitWithPlainText() throws {
+            let plainString = "This is plain text content"
+            try #require(!plainString.mayContainHTML, "Sanity Check: Plain text should not be detected as containing HTML")
+            #expect(AttributedString.StringProvider(plainString) == .attributedString(AttributedString(plainString)))
+        }
+    }
 }

--- a/FringePlannerTests/ExtensionTests/StringTests.swift
+++ b/FringePlannerTests/ExtensionTests/StringTests.swift
@@ -45,6 +45,28 @@ struct StringTests {
         #expect("Text before <span>and tag</span> after".mayContainHTML == true)
     }
     
+    @Test("`typographicallyEnhanced` correctly replaces typographic characters")
+    func testTypographicallyEnhanced() {
+        // Test quotes normalization
+        #expect("\u{201C}Hello World\u{201D}".typographicallyEnhanced == "\"Hello World\"")
+        #expect("It\u{2019}s working".typographicallyEnhanced == "It's working")
+        #expect("It\u{2018}s a \u{201C}quote\u{201D}".typographicallyEnhanced == "It's a \"quote\"")
+        
+        // Test ellipsis
+        #expect("Testing...done".typographicallyEnhanced == "Testing\u{2026}done")
+        
+        // Test symbols
+        #expect("Copyright (c) 2024".typographicallyEnhanced == "Copyright \u{00A9} 2024")
+        #expect("Registered (r) mark".typographicallyEnhanced == "Registered \u{00AE} mark")
+        #expect("Trademark (tm) symbol".typographicallyEnhanced == "Trademark \u{2122} symbol")
+        
+        // Test dashes
+        #expect("Word--connection".typographicallyEnhanced == "Word\u{2014}connection")
+        
+        // Test multiple substitutions
+        #expect("\u{201C}Hello World\u{201D}... It\u{2019}s (c) 2024".typographicallyEnhanced == "\"Hello World\"\u{2026} It's \u{00A9} 2024")
+    }
+    
     @Test("`withoutHTMLTags` correctly removes HTML tags")
     func testWithoutHTMLTags() {
         // Empty string

--- a/FringePlannerTests/ExtensionTests/StringTests.swift
+++ b/FringePlannerTests/ExtensionTests/StringTests.swift
@@ -30,4 +30,18 @@ struct StringTests {
         #expect("  test  ".nilOnEmpty == "  test  ")
         #expect("  test".nilOnEmpty == "  test")
     }
+    
+    @Test("`mayContainHTML` correctly identifies HTML content")
+    func testMayContainHTML() {
+        // Possibly no HTML
+        #expect("".mayContainHTML == false)
+        #expect("Plain text content".mayContainHTML == false)
+        #expect("Text with brackets but not tags: 2 < 3 and 5 > 4".mayContainHTML == false)
+        // May include HTML
+        #expect("<p>Simple paragraph</p>".mayContainHTML == true)
+        #expect("<div class=\"test\">With attributes</div>".mayContainHTML == true)
+        #expect("<br/>".mayContainHTML == true)
+        #expect("<img src=\"image.jpg\" alt=\"Image\">".mayContainHTML == true)
+        #expect("Text before <span>and tag</span> after".mayContainHTML == true)
+    }
 }

--- a/FringePlannerTests/ExtensionTests/StringTests.swift
+++ b/FringePlannerTests/ExtensionTests/StringTests.swift
@@ -44,4 +44,40 @@ struct StringTests {
         #expect("<img src=\"image.jpg\" alt=\"Image\">".mayContainHTML == true)
         #expect("Text before <span>and tag</span> after".mayContainHTML == true)
     }
+    
+    @Test("`withoutHTMLTags` correctly removes HTML tags")
+    func testWithoutHTMLTags() {
+        // Empty string
+        #expect("".withoutHTMLTags == "")
+        
+        // Plain text (no change expected)
+        #expect("Plain text content".withoutHTMLTags == "Plain text content")
+        #expect("Text with brackets like 2 < 3 and 5 > 4".withoutHTMLTags == "Text with brackets like 2 < 3 and 5 > 4")
+        
+        // Basic HTML tags
+        #expect("<p>Simple paragraph</p>".withoutHTMLTags == "Simple paragraph")
+        #expect("<br/>".withoutHTMLTags == "")
+        #expect("<div>Content</div>".withoutHTMLTags == "Content")
+        
+        // HTML with attributes
+        #expect("<div class=\"test\">With attributes</div>".withoutHTMLTags == "With attributes")
+        #expect("<img src=\"image.jpg\" alt=\"Image\">".withoutHTMLTags == "")
+        
+        // Nested tags
+        #expect("<div><p>Nested content</p></div>".withoutHTMLTags == "Nested content")
+        #expect("<ul><li>Item 1</li><li>Item 2</li></ul>".withoutHTMLTags == "Item 1Item 2")
+        
+        // Mixed content
+        #expect("Text before <span>and tag</span> after".withoutHTMLTags == "Text before and tag after")
+        #expect("Line 1<br>Line 2".withoutHTMLTags == "Line 1Line 2")
+        
+        // Complex HTML
+        let complexHTML = """
+        <div class="container">
+          <h1>Title</h1>
+          <p>This is a <b>paragraph</b> with <i>formatted</i> text.</p>
+        </div>
+        """
+        #expect(complexHTML.withoutHTMLTags == "\n  Title\n  This is a paragraph with formatted text.\n")
+    }
 }


### PR DESCRIPTION
There were still existing issues with the HTML renderer for AttributedString, giving a bad user experience where all content had to be loaded asynchronously in order for the application not to crash. This changes verifies if the string used includes any HTML, if it doesn't it will immediately be set as a AttributedString, otherwise it will render later on the MainActor